### PR TITLE
Update branding from EduVoice AI to SHUNYA AI

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -32,7 +32,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
         'HTTP-Referer': REFERER,
-        'X-Title': 'EduVoice AI',
+        'X-Title': 'SHUNYA AI',
       },
       body: JSON.stringify({
         model: selectedModel,
@@ -51,7 +51,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             'Authorization': `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
             'HTTP-Referer': REFERER,
-            'X-Title': 'EduVoice AI',
+            'X-Title': 'SHUNYA AI',
           },
           body: JSON.stringify({
             model: selectedModel,

--- a/api/mindmap.ts
+++ b/api/mindmap.ts
@@ -57,7 +57,7 @@ Create a hierarchical structure that represents the key concepts and their relat
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
         'HTTP-Referer': REFERER,
-        'X-Title': 'EduVoice AI',
+        'X-Title': 'SHUNYA AI',
       },
       body: JSON.stringify({
         model: selectedModel,
@@ -76,7 +76,7 @@ Create a hierarchical structure that represents the key concepts and their relat
             'Authorization': `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
             'HTTP-Referer': REFERER,
-            'X-Title': 'EduVoice AI',
+            'X-Title': 'SHUNYA AI',
           },
           body: JSON.stringify({
             model: selectedModel,

--- a/api/quiz.ts
+++ b/api/quiz.ts
@@ -51,7 +51,7 @@ The correctAnswer should be the index (0-3) of the correct option.`;
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
         'HTTP-Referer': REFERER,
-        'X-Title': 'EduVoice AI',
+        'X-Title': 'SHUNYA AI',
       },
       body: JSON.stringify({
         model: selectedModel,
@@ -70,7 +70,7 @@ The correctAnswer should be the index (0-3) of the correct option.`;
             'Authorization': `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
             'HTTP-Referer': REFERER,
-            'X-Title': 'EduVoice AI',
+            'X-Title': 'SHUNYA AI',
           },
           body: JSON.stringify({
             model: selectedModel,

--- a/api/vision.ts
+++ b/api/vision.ts
@@ -50,7 +50,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
         'HTTP-Referer': REFERER,
-        'X-Title': 'EduVoice AI',
+        'X-Title': 'SHUNYA AI',
       },
       body: JSON.stringify({
         model: selectedModel,
@@ -68,7 +68,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             'Authorization': `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
             'HTTP-Referer': REFERER,
-            'X-Title': 'EduVoice AI',
+            'X-Title': 'SHUNYA AI',
           },
           body: JSON.stringify({
             model: selectedModel,

--- a/index.html
+++ b/index.html
@@ -3,19 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EduVoice AI - The Talking Visual Learning Platform</title>
-    <meta name="description" content="Your AI teacher that listens, sees, and teaches you visually. Upload PDFs, images, videos and get instant mind maps, explanations, and personalized quizzes powered by GPT-4, Claude, and Gemini." />
-    <meta name="author" content="EduVoice AI" />
+    <title>SHUNYA AI — the beginning of infinite intelligence</title>
+    <meta name="description" content="SHUNYA AI — the beginning of infinite intelligence. A mindful intelligence workspace unifying voice, vision, and knowledge synthesis into lucid mind maps, narrated guidance, and adaptive practice." />
+    <meta name="author" content="SHUNYA AI" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 
-    <meta property="og:title" content="EduVoice AI - Talking Visual Learning Platform" />
-    <meta property="og:description" content="AI-powered visual learning with mind maps, explanations, and quizzes. Powered by GPT-4, Claude, and Gemini." />
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+
+    <meta property="og:title" content="SHUNYA AI — the beginning of infinite intelligence" />
+    <meta property="og:description" content="A tranquil, multi‑sensory workspace for composing infinite intelligence through voice, vision, and knowledge synthesis." />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@eduvoice_ai" />
+    <meta name="twitter:site" content="@shunya_ai" />
   </head>
 
   <body>


### PR DESCRIPTION
## Purpose

The user requested a complete website rebrand to "SHUNYA AI — the beginning of infinite intelligence" with updated branding throughout the site, replacing the old EduVoice AI branding and ensuring consistency across all components.

## Code changes

- **API Headers**: Updated `X-Title` header from "EduVoice AI" to "SHUNYA AI" across all API endpoints (chat.ts, mindmap.ts, quiz.ts, vision.ts)
- **HTML Meta Tags**: Updated page title, description, author, and Open Graph metadata to reflect SHUNYA AI branding
- **Favicon**: Added favicon references in HTML head section
- **Social Media**: Updated Twitter handle reference from @eduvoice_ai to @shunya_ai
- **Brand Messaging**: Replaced educational focus with "mindful intelligence workspace" and "infinite intelligence" positioning

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c32ecf20931a49ab86f3201544181f54/aura-works)

👀 [Preview Link](https://c32ecf20931a49ab86f3201544181f54-aura-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c32ecf20931a49ab86f3201544181f54</projectId>-->
<!--<branchName>aura-works</branchName>-->